### PR TITLE
Preventing Heredoc's error when compiling code.

### DIFF
--- a/view/adminhtml/templates/system/config/intro.phtml
+++ b/view/adminhtml/templates/system/config/intro.phtml
@@ -1,15 +1,9 @@
-<?php  $html = <<<EOD
 <div class="extend__intro">
-    <img id="extend-logo" src="{$this->getViewFileUrl('Extend_Warranty::images/Extend_logo_slogan.svg')}" alt="Logo Image">
+    <img id="extend-logo" src="<?= $this->getViewFileUrl('Extend_Warranty::images/Extend_logo_slogan.svg'); ?>" alt="Logo Image">
     <div class="extend__info">
-        <p id="extend-intro">Extend generates new revenue for your store, increases overall purchase 
-                conversions, and provides customers with streamlined product protection and peace of mind.</p>
+        <p id="extend-intro">Extend generates new revenue for your store, increases overall purchase
+            conversions, and provides customers with streamlined product protection and peace of mind.</p>
         <p><a href="https://extend.com/faq/">Learn more</a></p>
     </div>
-    <img id="extend-mobile" src="{$this->getViewFileUrl('Extend_Warranty::images/mobile-offer.svg')}" alt="Mobile Image">
+    <img id="extend-mobile" src="<?= $this->getViewFileUrl('Extend_Warranty::images/mobile-offer.svg'); ?>" alt="Mobile Image">
 </div>
-EOD;
-?>
-
-
-<?= $html ?>


### PR DESCRIPTION
Preventing Heredoc errors on magento code compilation.

The problem is related to the HEREDOC of the intro.phtml template and the Magento code compression for the cache, since the HEREDOC does not allow extra spaces in its syntax (Magento when compressing the file decomposed the HEREDOC syntax), I refactored the template.