### PR TITLE
Fixing normalization on updateProduct page.

### DIFF
--- a/Observer/Warranty/Normalize.php
+++ b/Observer/Warranty/Normalize.php
@@ -8,6 +8,9 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Extend\Warranty\Helper\Api\Data;
 
+use Magento\Checkout\Model\Cart;
+use Magento\Checkout\Model\Session as CheckoutSession;
+
 class Normalize implements ObserverInterface
 {
     /**
@@ -20,10 +23,23 @@ class Normalize implements ObserverInterface
      */
     protected $helper;
 
-    public function __construct(Normalizer $normalizer, Data $helper)
+    /**
+     * @var CheckoutSession
+     */
+    protected $checkoutSession;
+
+    /**
+     * @var Cart
+     */
+    protected $cart;
+
+
+    public function __construct(Normalizer $normalizer, Data $helper, CheckoutSession $checkoutSession, Cart $cart)
     {
         $this->normalizer = $normalizer;
         $this->helper = $helper;
+        $this->checkoutSession = $checkoutSession;
+        $this->cart = $cart;
 
     }
 
@@ -36,8 +52,49 @@ class Normalize implements ObserverInterface
             return;
         }
 
-        $cart = $observer->getEvent()->getCart();
+        $_cart = $observer->getEvent()->getCart();
 
-        $this->normalizer->normalize($cart);
+        /* Normalize on quote/cart update */
+        if (empty($_cart)) {
+            $this->_normalize($this->checkoutSession->getQuote());
+        } else {
+            $this->normalizer->normalize($_cart);
+        }
+    }
+
+    private function _normalize($quote) {
+
+        //split cart items from products and warranties
+        $warranties = [];
+        $products = [];
+
+        foreach ($quote->getAllItems() as $item) {
+            if ($item->getProductType() === 'warranty') {
+                $warranties[$item->getItemId()] = $item;
+            } else {
+                $products[] = $item;
+            }
+        }
+
+        //Loop products to see if their qty is different from the warranty qty and adjust both to max
+        foreach ($products as $item) {
+            $sku = $item->getSku();
+
+            foreach ($warranties as $warrantyitem) {
+                if ($warrantyitem->getOptionByCode('associated_product')->getValue() == $sku &&
+                    ($item->getProductType() == 'configurable' || is_null($item->getOptionByCode('parent_product_id')))) {
+                    if ($warrantyitem->getQty() <> $item->getQty()) {
+                        if ($item->getQty() > 0) {
+                            //Update Warranty QTY
+                            $warrantyitem->setQty($item->getQty());
+                            $warrantyitem->calcRowTotal();
+                            $warrantyitem->save();
+                        }
+                    }
+                }
+            }
+        }
+        $quote->setTriggerRecollect(1);
+        $quote->collectTotals()->save();
     }
 }

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -9,4 +9,7 @@
     <event name="checkout_cart_update_items_after">
         <observer name="cart_normalize" instance="Extend\Warranty\Observer\Warranty\Normalize"/>
     </event>
+    <event name="checkout_cart_update_item_complete">
+        <observer name="cart_normalize" instance="Extend\Warranty\Observer\Warranty\Normalize"/>
+    </event>
 </config>


### PR DESCRIPTION
On the update page Product.
(Using the pencil button from the Cart Page).

Now the normalization of warranties is functional. 