### PR TITLE
Ex 18 - BUG FIX: Adding different variants of the same config product with Extend

### DIFF
--- a/Observer/Warranty/RemoveWarranties.php
+++ b/Observer/Warranty/RemoveWarranties.php
@@ -37,11 +37,21 @@ class RemoveWarranties implements ObserverInterface
             $quote = $this->cart->getQuote();
             $items = $quote->getAllItems();
 
+            $removeWarranty = true;
             foreach ($items as $item) {
-                if ($item->getProductType() === WarrantyType::TYPE_CODE &&
-                    $item->getOptionByCode('associated_product')->getValue() === $sku) {
+                if ($item->getSku() === $sku) {
+                    $removeWarranty = false;
+                    break;
+                }
+            }
 
-                    $quote->removeItem($item->getItemId());
+            if ($removeWarranty) {
+                foreach ($items as $item) {
+                    if ($item->getProductType() === WarrantyType::TYPE_CODE &&
+                        $item->getOptionByCode('associated_product')->getValue() === $sku) {
+
+                        $quote->removeItem($item->getItemId());
+                    }
                 }
             }
         }

--- a/Plugin/ConfigurableProduct/Model/Quote/Item/CartItemProcessorPlugin.php
+++ b/Plugin/ConfigurableProduct/Model/Quote/Item/CartItemProcessorPlugin.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Extend Warranty
+ *
+ * @author      Extend Magento Team <magento@guidance.com>
+ * @category    Extend
+ * @package     Warranty
+ * @copyright   Copyright (c) 2021 Extend Inc. (https://www.extend.com/)
+ */
+
+namespace Extend\Warranty\Plugin\ConfigurableProduct\Model\Quote\Item;
+
+use Magento\ConfigurableProduct\Model\Quote\Item\CartItemProcessor;
+use Magento\Quote\Api\Data\CartItemInterface;
+
+/**
+ * Class CartItemProcessorPlugin
+ */
+class CartItemProcessorPlugin
+{
+    /**
+     * Prevent method call if custom option is null
+     *
+     * @param CartItemProcessor $subject
+     * @param callable $proceed
+     * @param CartItemInterface $cartItem
+     * @return CartItemInterface
+     */
+    public function aroundProcessOptions(
+        CartItemProcessor $subject,
+        callable $proceed,
+        CartItemInterface $cartItem
+    ) {
+        $product = $cartItem->getProduct();
+        $attributesOption = $product->getCustomOption('attributes');
+
+        if (!$attributesOption) {
+            return $cartItem;
+        } else {
+            return $proceed($cartItem);
+        }
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Extend Warranty
+ *
+ * @author      Extend Magento Team <magento@guidance.com>
+ * @category    Extend
+ * @package     Warranty
+ * @copyright   Copyright (c) 2021 Extend Inc. (https://www.extend.com/)
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\ConfigurableProduct\Model\Quote\Item\CartItemProcessor">
+        <plugin name="ExtendWarrantyCartItemProcessorPlugin"
+                type="Extend\Warranty\Plugin\ConfigurableProduct\Model\Quote\Item\CartItemProcessorPlugin"
+                sortOrder="10" />
+    </type>
+</config>


### PR DESCRIPTION
Adding different variants of the same config product with Extend caused the the cart to dump the physical sku and add an orphan extend sku. 

This change support configurable swatch and dropdown products. 