### PR TITLE
Update patch to emulate adminhtml area

### DIFF
--- a/Setup/Patch/Data/AddWarrantyProductPatch.php
+++ b/Setup/Patch/Data/AddWarrantyProductPatch.php
@@ -98,6 +98,11 @@ class AddWarrantyProductPatch implements DataPatchInterface, PatchRevertableInte
     private $imageContentFactory;
 
     /**
+     * @var State
+     */
+    private $state;
+
+    /**
      * @param ModuleDataSetupInterface $moduleDataSetup
      * @param ProductFactory $productFactory
      * @param EavSetupFactory $eavSetupFactory
@@ -137,7 +142,7 @@ class AddWarrantyProductPatch implements DataPatchInterface, PatchRevertableInte
         $this->mediaGalleryEntryFactory = $mediaGalleryEntryFactory;
         $this->mediaGalleryManagement = $mediaGalleryManagement;
         $this->imageContentFactory = $imageContentFactory;
-        $state->setAreaCode(Area::AREA_ADMINHTML);
+        $this->state = $state;
     }
 
     /**
@@ -145,7 +150,7 @@ class AddWarrantyProductPatch implements DataPatchInterface, PatchRevertableInte
      */
     public static function getDependencies()
     {
-            return [];
+        return [];
     }
 
     /**
@@ -163,9 +168,11 @@ class AddWarrantyProductPatch implements DataPatchInterface, PatchRevertableInte
     {
         $this->moduleDataSetup->getConnection()->startSetup();
         //ADD WARRANTY PRODUCT TO THE DB
-        $this->addImageToPubMedia();
-        $this->createWarrantyProduct();
-        $this->enablePriceForWarrantyProducts();
+        $this->state->emulateAreaCode(Area::AREA_ADMINHTML, function () {
+            $this->addImageToPubMedia();
+            $this->createWarrantyProduct();
+            $this->enablePriceForWarrantyProducts();
+        });
 
         $this->moduleDataSetup->getConnection()->endSetup();
     }
@@ -177,7 +184,9 @@ class AddWarrantyProductPatch implements DataPatchInterface, PatchRevertableInte
     {
         $this->moduleDataSetup->getConnection()->startSetup();
 
-        $this->deleteImageFromPubMedia();
+        $this->state->emulateAreaCode(Area::AREA_ADMINHTML, function () {
+            $this->deleteImageFromPubMedia();
+        });
 
         $this->moduleDataSetup->getConnection()->endSetup();
     }


### PR DESCRIPTION
To replicate the Area Already Set issue: 
- Ensure Magento Docker is setup and running.
- Ensure that the Extension is installed and enabled.
- Drop the all data in the existing db schema so that the following command will run a fresh magento installation.
- Run `docker-compose run --rm deploy cloud-deploy`