### PR TITLE
[EX-377] [M2] - Users are able to see, add to cart and check out with…

### DIFF
--- a/Model/Normalizer.php
+++ b/Model/Normalizer.php
@@ -116,6 +116,7 @@ class Normalizer
 
                 if ($relatedItemId && $relatedItemId->getValue() === $productItem->getId()) {
                     $warranties[$warrantyItem->getItemId()] = $warrantyItem;
+                    unset($warrantyItems[$warrantyItem->getItemId()]);
                 }
             }
 
@@ -150,6 +151,17 @@ class Normalizer
                 }
             } else {
                 $this->normalizeWarrantiesAgainstProductQty($warranties, $productItem->getQty(), $cart, $quote);
+            }
+        }
+
+        //removing the warranty items which doesn't have relations
+        if (count($warrantyItems)) {
+            if ($warrantyItems) {
+                foreach ($warrantyItems as $warrantyItem) {
+                    $warrantyItem->setHasError(true);
+                    $warrantyItem->setMessage('Warranty can\'t be added to cart');
+                    $quote->deleteItem($warrantyItem);
+                }
             }
         }
     }

--- a/Plugin/Checkout/CustomerData/LastOrderedItemsPlugin.php
+++ b/Plugin/Checkout/CustomerData/LastOrderedItemsPlugin.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Extend Warranty
+ *
+ * @author      Extend Magento Team <magento@guidance.com>
+ * @category    Extend
+ * @package     Warranty
+ * @copyright   Copyright (c) 2021 Extend Inc. (https://www.extend.com/)
+ */
+
+namespace Extend\Warranty\Plugin\Checkout\CustomerData;
+
+use \Magento\Sales\Model\ResourceModel\Order\Item\CollectionFactory as OrderItemCollectionFactory;
+use \Magento\Sales\CustomerData\LastOrderedItems;
+use \Extend\Warranty\Model\Product\Type as WarrantyProductType;
+
+class LastOrderedItemsPlugin
+{
+
+    /**
+     * @var OrderItemCollectionFactory
+     */
+    protected $orderItemCollectionFactory;
+
+    /**
+     * @param OrderItemCollectionFactory $orderItemCollectionFactory
+     */
+    public function __construct(OrderItemCollectionFactory $orderItemCollectionFactory)
+    {
+        $this->orderItemCollectionFactory = $orderItemCollectionFactory;
+    }
+
+    /**
+     * @param LastOrderedItems $subject
+     * @param array $result
+     * @return array
+     */
+    public function afterGetSectionData($subject, $result)
+    {
+        $orderItemCollection = $this->orderItemCollectionFactory->create();
+
+        if (isset($result['items'])) {
+            $itemIds = array_column($result['items'], 'id');
+            $orderItemCollection->addFieldToFilter('item_id', $itemIds);
+
+            foreach ($result['items'] as $key => $item) {
+                if (
+                    $orderItem = $orderItemCollection->getItemById($item['id'])
+                ) {
+                    if ($orderItem && $orderItem->getProductType() == WarrantyProductType::TYPE_CODE) {
+                        unset($result['items'][$key]);
+                    }
+                }
+            }
+        }
+
+        $result['items'] = array_values($result['items']);
+        return $result;
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -30,4 +30,8 @@
         <observer name="extend_warranty_create_warranty_order_after_observer"
                   instance="Extend\Warranty\Observer\ContractCreate\OrderObserver"/>
     </event>
+    <event name="sales_quote_product_add_after">
+        <observer name="extend_warranty_observer_warranty_add_to_cart_check"
+                  instance="\Extend\Warranty\Observer\Warranty\Normalize" />
+    </event>
 </config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -49,4 +49,8 @@
                 type="Extend\Warranty\Plugin\Checkout\CustomerData\CartPlugin"
                 sortOrder="10" />
     </type>
+    <type name="\Magento\Sales\CustomerData\LastOrderedItems">
+        <plugin name="filterLastOrderItemsFromWarranties"
+                type="Extend\Warranty\Plugin\Checkout\CustomerData\LastOrderedItemsPlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
… only a warranty from the Recently Ordered section of the default Magento 2 account history page & Normalization fails to run on this page

- made Normalizer clean warranties which has no relation to warrantable products
- added filter for warranty product type in Last Ordered Items section