### PR TITLE
[EX-384] [M2] - Install extension failed in magento 2.3.7

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -33,7 +33,7 @@
         </constraint>
     </table>
     <table name="extend_historical_orders">
-        <column xsi:type="int" name="entity_id" identity="false" nullable="false" unsigned="true" comment="Order Id"/>
+        <column xsi:type="int" name="entity_id" padding="10" identity="false" nullable="false" unsigned="true" comment="Order Id"/>
         <column xsi:type="smallint" name="was_sent" identity="false" nullable="false" unsigned="true" default="0" comment="Order sent status"/>
         <constraint xsi:type="foreign" referenceId="EXTEND_HISTORICAL_ORDERS_SALES_ORDER_ENTITY_ID"
                     table="extend_historical_orders" column="entity_id" referenceTable="sales_order"


### PR DESCRIPTION
- fixed issue with wrong column description for extend_historical_orders.entity_id