### PR TITLE
[EX-377] [M2] - Users are able to see, add to cart and check out with…

### DIFF
--- a/Model/Normalizer.php
+++ b/Model/Normalizer.php
@@ -127,6 +127,7 @@ class Normalizer
                         )
                     ) {
                         $warranties[$warrantyItem->getItemId()] = $warrantyItem;
+                        unset($warrantyItems[$warrantyItem->getItemId()]);
                     }
                 }
             }
@@ -162,6 +163,17 @@ class Normalizer
                 if ($productItemQty !== $warranty->getQty()) {
                     $warranty->setQty($productItemQty);
                     $this->quoteItemRepository->save($warranty);
+                }
+            }
+        }
+
+        //removing the warranty items which doesn't have relations
+        if (count($warrantyItems)) {
+            if ($warrantyItems) {
+                foreach ($warrantyItems as $warrantyItem) {
+                    $warrantyItem->setHasError(true);
+                    $warrantyItem->setMessage('Warranty can\'t be added to cart');
+                    $quote->deleteItem($warrantyItem);
                 }
             }
         }

--- a/Plugin/Checkout/CustomerData/LastOrderedItemsPlugin.php
+++ b/Plugin/Checkout/CustomerData/LastOrderedItemsPlugin.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Extend Warranty
+ *
+ * @author      Extend Magento Team <magento@guidance.com>
+ * @category    Extend
+ * @package     Warranty
+ * @copyright   Copyright (c) 2022 Extend Inc. (https://www.extend.com/)
+ */
+
+namespace Extend\Warranty\Plugin\Checkout\CustomerData;
+
+use \Magento\Sales\Model\ResourceModel\Order\Item\CollectionFactory as OrderItemCollectionFactory;
+use \Extend\Warranty\Model\Product\Type as WarrantyProductType;
+
+class LastOrderedItemsPlugin
+{
+    /**
+     * @var OrderItemCollectionFactory
+     */
+    protected $orderItemCollectionFactory;
+
+    /**
+     * @param OrderItemCollectionFactory $orderItemCollectionFactory
+     */
+    public function __construct(OrderItemCollectionFactory $orderItemCollectionFactory)
+    {
+        $this->orderItemCollectionFactory = $orderItemCollectionFactory;
+    }
+
+    /**
+     * @param $subject
+     * @param $result
+     * @return mixed
+     */
+    public function afterGetSectionData($subject, $result)
+    {
+        $orderItemCollection = $this->orderItemCollectionFactory->create();
+
+        if (isset($result['items'])) {
+            $itemIds = array_column($result['items'], 'id');
+            $orderItemCollection->addFieldToFilter('item_id', $itemIds);
+
+            foreach ($result['items'] as $key => $item) {
+                if (
+                    $orderItem = $orderItemCollection->getItemById($item['id'])
+                ) {
+                    if ($orderItem->getProductType() == WarrantyProductType::TYPE_CODE) {
+                        unset($result['items'][$key]);
+                    }
+                }
+            }
+        }
+
+        $result['items'] = array_values($result['items']);
+
+        return $result;
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -49,4 +49,9 @@
                 type="Extend\Warranty\Plugin\Checkout\CustomerData\CartPlugin"
                 sortOrder="10" />
     </type>
+
+    <type name="\Magento\Sales\CustomerData\LastOrderedItems">
+        <plugin name="filterLastOrderItemsFromWarranties"
+                type="Extend\Warranty\Plugin\Checkout\CustomerData\LastOrderedItemsPlugin"/>
+    </type>
 </config>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -18,6 +18,10 @@
         <observer name="extend_warranty_observer_checkout_cart_add"
                   instance="Extend\Warranty\Observer\Checkout\Cart\Add" />
     </event>
+    <event name="sales_quote_product_add_after">
+        <observer name="extend_warranty_observer_warranty_add_to_cart_check"
+                  instance="\Extend\Warranty\Observer\Warranty\Normalize" />
+    </event>
 
     <event name="sales_quote_remove_item">
         <observer name="extend_warranty_observer_quote_remove_item"


### PR DESCRIPTION
… only a warranty from the Recently Ordered section of the default Magento 2 account history page & Normalization fails to run on this page

- made Normalizer clean warranties which has no relation to warrantable products
- added filter for warranty product type in Last Ordered Items section