### PR TITLE
[EX-354] [M2] Support for bundled products

### DIFF
--- a/Controller/Cart/Add.php
+++ b/Controller/Cart/Add.php
@@ -10,6 +10,7 @@
 
 namespace Extend\Warranty\Controller\Cart;
 
+use Extend\Warranty\Helper\Data as WarrantyHelper;
 use Extend\Warranty\Model\Product\Type;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Checkout\Controller\Cart;
@@ -195,38 +196,24 @@ class Add extends Cart
             }
 
             $relatedProduct = $warrantyData['product'];
+            $relatedItemId = $warrantyData['related_item_id'] ?? null;
             $qty = 1;
 
             $quote = $this->_checkoutSession->getQuote();
             $items = $quote->getAllVisibleItems();
 
             foreach ($items as $item) {
-                $value = false;
-                $option = $item->getOptionByCode('associated_product');
-
-                if ($option instanceof \Magento\Quote\Model\Quote\Item\Option) {
-                    $value = $option->getValue();
-                }
-
-                if ($item->getProductType() === Type::TYPE_CODE && $value === $relatedProduct) {
-                    $this->cart->removeItem($item->getId());
+                if(!$relatedItemId && $relatedProduct == $item->getSku()){
+                    $relatedItemId = $item->getId();
                 }
 
                 $product = $item->getProduct();
-                $sku = $item->getSku();
 
-                if (
-                    $product->hasCustomOptions() && $product->getTypeId() === \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE ||
-                    $product->getTypeId() === 'bundle'
-                ) {
-                    $sku = $product->getData('sku');
-                }
-
-                if ($sku === $relatedProduct) {
+                if ($item->getId() === $relatedItemId) {
                     $qty = $item->getQty();
 
                     if ($product->getTypeId() === 'bundle') {
-                        $warrantyData[Type::DYNAMIC_SKU] = $sku;
+                        $warrantyData[Type::DYNAMIC_SKU] =  WarrantyHelper::getComplexProductSku($product);;
                     }
                 }
             }

--- a/Helper/Tracking.php
+++ b/Helper/Tracking.php
@@ -11,6 +11,8 @@ namespace Extend\Warranty\Helper;
 
 use Extend\Warranty\Model\Product\Type;
 use Magento\Quote\Model\Quote\Item;
+use Magento\Quote\Model\Quote;
+use Extend\Warranty\Helper\Data as WarrantyHelper;
 
 /**
  * Class Tracking
@@ -116,20 +118,21 @@ class Tracking extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Get Quote Item For Warranty Item
      *
-     * @param \Magento\Quote\Model\Quote\Item $quoteItem
-     * @return false|\Magento\Quote\Model\Quote\Item
+     * @param Item $quoteItem
+     * @return false|Item
      */
-    public function getQuoteItemForWarrantyItem(\Magento\Quote\Model\Quote\Item $quoteItem)
+    public function getQuoteItemForWarrantyItem(Item $quoteItem)
     {
         //find corresponding product and get qty
-        $warrantyIdOption = $quoteItem->getOptionByCode(Type::RELATED_ITEM_ID);
+        $warrantyId = (string)$quoteItem->getOptionByCode(Type::RELATED_ITEM_ID)->getValue();
         /** @var \Magento\Quote\Model\Quote $quote */
         $quote = $quoteItem->getQuote();
         foreach ($quote->getAllItems() as $item) {
             /** @var \Magento\Quote\Model\Quote\Item $item */
             $productId = $item->getId();
 
-            if ($warrantyIdOption && $warrantyIdOption->getValue() == $productId
+            /** @var Item $item */
+            if ($warrantyId == $productId
                 && ($item->getProductType() === \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE
                     || null === $item->getOptionByCode('parent_product_id'))
             ) {
@@ -143,48 +146,28 @@ class Tracking extends \Magento\Framework\App\Helper\AbstractHelper
     /**
      * Get Warranty Items For Quote Item
      *
-     * @param \Magento\Quote\Model\Quote\Item $quoteItem
-     * @return false|\Magento\Quote\Model\Quote\Item
+     * @param Item $quoteItem
+     * @return Item[]
      */
-    public function getWarrantyItemsForQuoteItem(\Magento\Quote\Model\Quote\Item $quoteItem)
+    public function getWarrantyItemsForQuoteItem(Item $quoteItem)
     {
         $possibleItems = [];
 
-        /** @var \Magento\Quote\Model\Quote $quote */
+        /** @var Quote $quote */
         $quote = $quoteItem->getQuote();
-        foreach ($quote->getAllItems() as $item) {
-            /** @var \Magento\Quote\Model\Quote\Item $item */
 
-            if ($item->getProductType() !== \Extend\Warranty\Model\Product\Type::TYPE_CODE) {
+        /** @var Item $item */
+        foreach ($quote->getAllItems() as $item) {
+
+            if ($item->getProductType() !== Type::TYPE_CODE) {
                 continue;
             } else {
-                if ($this->isWarrantyRelatedToItem($item, $quoteItem)) {
+                if (WarrantyHelper::isWarrantyRelatedToQuoteItem($item, $quoteItem, true)) {
                     $possibleItems[] = $item;
                 }
             }
         }
 
         return $possibleItems;
-    }
-
-    /**
-     * @param Item $warrantyItem
-     * @param Item $item
-     * @return bool
-     */
-    protected function isWarrantyRelatedToItem($warrantyItem, $item)
-    {
-        if($warrantyItem->getLeadToken() ||
-            ($warrantyItem->getExtensionAttributes()
-                && $warrantyItem->getExtensionAttributes()->getLeadToken())
-        ){
-            return false;
-        }
-        $relatedItemId = $warrantyItem->getOptionByCode(Type::RELATED_ITEM_ID);
-
-        $relatedCheck = !$relatedItemId || in_array($relatedItemId->getValue(), [$item->getId(), $item->getParentId()]);
-
-        $associatedProductSku = $warrantyItem->getOptionByCode(Type::ASSOCIATED_PRODUCT)->getValue();
-        return $relatedCheck || $item->getSku() == $associatedProductSku;
     }
 }

--- a/Model/Normalizer.php
+++ b/Model/Normalizer.php
@@ -10,6 +10,7 @@
 
 namespace Extend\Warranty\Model;
 
+use Extend\Warranty\Helper\Data as WarrantyHelper;
 use Extend\Warranty\Helper\Tracking as TrackingHelper;
 use Extend\Warranty\Model\Product\Type;
 use InvalidArgumentException;
@@ -24,6 +25,7 @@ use Magento\Quote\Api\CartItemRepositoryInterface;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Api\Data\CartItemExtension;
 use Magento\Quote\Model\Quote\Item;
+use Magento\Bundle\Model\Product\Type as BundleProductType;
 
 /**
  * Class Normalizer
@@ -93,81 +95,73 @@ class Normalizer
         $productItems = $warrantyItems = [];
 
         $cart = $this->cartHelper->getCart();
-
         foreach ($quote->getAllItems() as $quoteItem) {
             if ($quoteItem->getProductType() === Type::TYPE_CODE) {
                 $warrantyItems[$quoteItem->getItemId()] = $quoteItem;
+            } elseif (BundleProductType::TYPE_CODE == $quoteItem->getProductType()) {
+                $productItems[] = $quoteItem;
+                foreach ($quoteItem->getChildren() as $bundleChildItem) {
+                    $productItems[] = $bundleChildItem;
+                }
             } else {
                 $productItems[$quoteItem->getItemId()] = $quoteItem;
             }
         }
 
+        $usedWarranties = [];
         foreach ($productItems as $productItem) {
             $warranties = [];
 
-            $product = $productItem->getProduct();
-
             foreach ($warrantyItems as $warrantyItem) {
-
                 if ($this->checkLeadToken($warrantyItem)) {
                     unset($warrantyItems[$warrantyItem->getItemId()]);
                     continue;
                 }
 
-                if ($this->isWarrantyQuoteItemMatch($warrantyItem, $productItem)) {
+                if (WarrantyHelper::isWarrantyRelatedToQuoteItem($warrantyItem, $productItem)) {
                     $warranties[$warrantyItem->getItemId()] = $warrantyItem;
-                    unset($warrantyItems[$warrantyItem->getItemId()]);
+                    $usedWarranties[$warrantyItem->getItemId()] = $warrantyItem->getItemId();
                 }
             }
 
-            if ($productItem->getProductType() === 'bundle') {
-                $productItemQty = $productItem->getQty();
-                foreach ($warranties as $warrantyItem) {
-                    $associatedProductOption = $warrantyItem->getOptionByCode(Type::ASSOCIATED_PRODUCT);
-                    $dynamicSku = $warrantyItem->getOptionByCode(Type::DYNAMIC_SKU);
-                    if ($dynamicSku && $associatedSku = $dynamicSku->getValue()) {
-                        if ($associatedSku === $product->getData('sku')) {
-                            $this->normalizeWarrantiesAgainstProductQty([$warrantyItem], $productItemQty, $cart, $quote);
-                            unset($warranties[$warrantyItem->getItemId()]);
-                        }
-                    } else if ($associatedProductOption && $associatedSku = $associatedProductOption->getValue()) {
-                        foreach ($productItem->getChildren() as $item) {
-                            if ($item->getProduct()->getData('sku') === $associatedSku) {
-                                if ($qty = $item->getQty()) {
-                                    $this->normalizeWarrantiesAgainstProductQty([$warrantyItem], $productItemQty * $qty, $cart, $quote);
-                                    unset($warranties[$warrantyItem->getItemId()]);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
+            $this->normalizeWarrantiesAgainstProductQty($warranties, $productItem->getTotalQty(), $cart, $quote);
+        }
 
-                if (count($warranties)) {
-                    foreach ($warranties as $warranty) {
-                        $cart->removeItem($warranty->getItemId());
-                    }
-                    $cart->save();
-                }
-            } else {
-                $this->normalizeWarrantiesAgainstProductQty($warranties, $productItem->getTotalQty(), $cart, $quote);
-            }
+        foreach ($usedWarranties as $warrantyItemId) {
+            unset($warrantyItems[$warrantyItemId]);
         }
 
         //removing the warranty items which doesn't have relations
         if (count($warrantyItems)) {
-            if ($warrantyItems) {
-                foreach ($warrantyItems as $warrantyItem) {
-                    if (!$this->checkLeadToken($warrantyItem)) {
-                        $cart->removeItem($warrantyItem->getItemId());
-                    }
+            foreach ($warrantyItems as $warrantyItem) {
+                if (!$this->checkLeadToken($warrantyItem)) {
+                    $cart->removeItem($warrantyItem->getItemId());
                 }
-                $cart->save();
             }
+            $cart->save();
         }
     }
 
-    private function normalizeWarrantiesAgainstProductQty(array $warranties, int $productItemQty, \Magento\Checkout\Model\Cart $cart, CartInterface $quote) {
+    /**
+     * Updated warranties qty following
+     * related product Total Qty
+     * or removes warranties when product qty < warranties qty
+     *
+     * @param Item[] $warranties
+     * @param int $productItemQty
+     * @param \Magento\Checkout\Model\Cart $cart
+     * @param CartInterface $quote
+     * @return void
+     * @throws CouldNotSaveException
+     * @throws InputException
+     * @throws NoSuchEntityException
+     */
+    private function normalizeWarrantiesAgainstProductQty(
+        array $warranties,
+        int $productItemQty,
+        \Magento\Checkout\Model\Cart $cart,
+        CartInterface $quote
+    ) {
         if (count($warranties) > 1) {
             $warrantyItemsQty = $this->getWarrantyItemsQty($warranties);
             if ($productItemQty > $warrantyItemsQty) {
@@ -262,6 +256,10 @@ class Normalizer
     }
 
     /**
+     * Checks if warranty item was created via lead token
+     *
+     * Should be moved to helper if needed somewhere else
+     *
      * @param Item $item
      * @return bool
      */
@@ -271,32 +269,5 @@ class Normalizer
             return true;
         }
         return false;
-    }
-
-    /**
-     * @param $warrantyItem
-     * @param $quoteItem
-     * @return bool
-     */
-    protected function isWarrantyQuoteItemMatch($warrantyItem, $quoteItem)
-    {
-        $relatedItemOption = $warrantyItem->getOptionByCode(Type::RELATED_ITEM_ID);
-        $associatedProductSku = $warrantyItem->getOptionByCode(Type::ASSOCIATED_PRODUCT);
-
-        if ($relatedItemOption) {
-            $relatedCheck = in_array($relatedItemOption->getValue(), [$quoteItem->getId(), $quoteItem->getParentItemId()]);
-        } else {
-            // if no related id specified lets skip it
-            $relatedCheck = true;
-        }
-
-        /**
-         * "relatedItemId" check should avoid situation when two quote item
-         * has same sku but connected to different warranty items.
-         *
-         * This case possible with bundles, when two different bundle could
-         * have same warrantable children
-         */
-        return $relatedCheck && $quoteItem->getSku() == $associatedProductSku->getValue();
     }
 }

--- a/Model/Quote/WarrantyRelation.php
+++ b/Model/Quote/WarrantyRelation.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Extend Warranty
+ *
+ * @author      Extend Magento Team <magento@guidance.com>
+ * @category    Extend
+ * @package     Warranty
+ * @copyright   Copyright (c) 2022 Extend Inc. (https://www.extend.com/)
+ */
+
+namespace Extend\Warranty\Model\Quote;
+
+use Extend\Warranty\Model\Product\Type;
+use Magento\Framework\Model\ResourceModel\Db\VersionControl\RelationInterface;
+
+
+class WarrantyRelation implements RelationInterface
+{
+
+    /**
+     * Once quote_item updated and item_id changed in Quote::updateItem()
+     * we need to change related_item_id for warranty quote item to keep this relation
+     *
+     * @param \Magento\Framework\Model\AbstractModel $object
+     * @return void
+     */
+    public function processRelation(\Magento\Framework\Model\AbstractModel $object)
+    {
+        if ($object->itemsCollectionWasSet()) {
+            foreach ($object->getItemsCollection() as $item) {
+                if ($item->getProductType() == Type::TYPE_CODE && $item->hasRelatedItem()) {
+                    $item->getOptionByCode(Type::RELATED_ITEM_ID)
+                        ->setValue($item->getRelatedItem()->getId());
+                    $item->saveItemOptions();
+                    $item->unsetRelatedItem();
+                }
+            }
+        }
+    }
+}

--- a/Observer/QuoteRemoveItem.php
+++ b/Observer/QuoteRemoveItem.php
@@ -9,7 +9,8 @@
  */
 namespace Extend\Warranty\Observer;
 
-use Extend\Warranty\Model\Product\Type;
+use Extend\Warranty\Helper\Data as WarrantyHelper;
+use Extend\Warranty\Model\Product\Type as WarrantyProductType;
 
 /**
  * Class QuoteRemoveItem
@@ -46,9 +47,9 @@ class QuoteRemoveItem implements \Magento\Framework\Event\ObserverInterface
         $quote = $quoteItem->getQuote();
 
         //if the item being removed is a warranty offer, send tracking for the offer removed, if tracking enabled
-        if ($quoteItem->getProductType() === \Extend\Warranty\Model\Product\Type::TYPE_CODE) {
+        if ($quoteItem->getProductType() === WarrantyProductType::TYPE_CODE) {
             if ($this->_trackingHelper->isTrackingEnabled()) {
-                $relatedItemIdOption = $quoteItem->getOptionByCode(Type::RELATED_ITEM_ID);
+                $relatedItemIdOption = $quoteItem->getOptionByCode(WarrantyProductType::RELATED_ITEM_ID);
                 $warrantySku = (string)$quoteItem->getOptionByCode('associated_product')->getValue();
                 $planId = (string)$quoteItem->getOptionByCode('warranty_id')->getValue();
                 $trackingData = [
@@ -62,7 +63,7 @@ class QuoteRemoveItem implements \Magento\Framework\Event\ObserverInterface
                 $trackProduct = true;
                 $items = $quote->getAllItems();
                 foreach ($items as $item) {
-                    if ($relatedItemIdOption && $item->getId() === $relatedItemIdOption->getValue()) {
+                    if ($relatedItemIdOption && $item->getId() == $relatedItemIdOption->getValue()) {
                         $trackProduct = false;
                         break;
                     }
@@ -94,18 +95,20 @@ class QuoteRemoveItem implements \Magento\Framework\Event\ObserverInterface
             return;
         }
 
-        //there is an associated warranty item, remove it
-        //the removal will dispatch this event again where the offer removal will be tracked above
+        /**
+         * there is an associated warranty item, remove it
+         * the removal will dispatch this event again where the offer removal will be tracked above
+         */
 
         $removeWarranty = true;
         $items = $quote->getAllItems();
         foreach ($items as $item) {
             /**
-             * This is covers a case when quote updates item by recreating it,
-             * so warranty shouldn't be deleted while there connected
-             *
+             * This is covers a case when quote updates item by recreating it
+             * (remove and then add a new one),
+             * so warranty shouldn't be deleted while there other item with same sku
             **/
-            if ($item->getSku() === $quoteItem->getSku()) {
+            if (WarrantyHelper::getComplexProductSku($item->getProduct()) === WarrantyHelper::getComplexProductSku($quoteItem->getProduct())) {
                 $removeWarranty = false;
                 break;
             }

--- a/Observer/QuoteRemoveItem.php
+++ b/Observer/QuoteRemoveItem.php
@@ -100,6 +100,11 @@ class QuoteRemoveItem implements \Magento\Framework\Event\ObserverInterface
         $removeWarranty = true;
         $items = $quote->getAllItems();
         foreach ($items as $item) {
+            /**
+             * This is covers a case when quote updates item by recreating it,
+             * so warranty shouldn't be deleted while there connected
+             *
+            **/
             if ($item->getSku() === $quoteItem->getSku()) {
                 $removeWarranty = false;
                 break;

--- a/Observer/Warranty/AddToCart.php
+++ b/Observer/Warranty/AddToCart.php
@@ -10,6 +10,9 @@
 
 namespace Extend\Warranty\Observer\Warranty;
 
+use Extend\Warranty\Helper\Data as WarrantyHelper;
+use Extend\Warranty\Model\Product\Type as WarrantyProductType;
+
 /**
  * Class AddToCart
  *
@@ -162,9 +165,9 @@ class AddToCart implements \Magento\Framework\Event\ObserverInterface
                 }
             } else {
                 $qty = $request->getPost('qty', 1);
-                $warrantyData = $request->getPost('warranty', []);
-                $warrantyData[\Extend\Warranty\Model\Product\Type::DYNAMIC_SKU] = $product->getData('sku');
-
+                if($warrantyData = $request->getPost('warranty', [])){
+                    $warrantyData[WarrantyProductType::DYNAMIC_SKU] = WarrantyHelper::getComplexProductSku($product);
+                }
                 $this->addWarranty($cart, $warrantyData, $qty, $product);
             }
         } else {
@@ -220,7 +223,7 @@ class AddToCart implements \Magento\Framework\Event\ObserverInterface
         }
 
         $this->_searchCriteriaBuilder
-            ->setPageSize(1)->addFilter('type_id', \Extend\Warranty\Model\Product\Type::TYPE_CODE);
+            ->setPageSize(1)->addFilter('type_id', WarrantyProductType::TYPE_CODE);
         /** @var \Magento\Framework\Api\SearchCriteria $searchCriteria */
         $searchCriteria = $this->_searchCriteriaBuilder->create();
         $searchResults = $this->_productRepository->getList($searchCriteria);
@@ -242,7 +245,7 @@ class AddToCart implements \Magento\Framework\Event\ObserverInterface
         }
         $relatedItem = $cart->getQuote()->getItemByProduct($product);
         $warrantyData['qty'] = $qty;
-        $warrantyData[\Extend\Warranty\Model\Product\Type::RELATED_ITEM_ID] = $relatedItem->getId();
+        $warrantyData[WarrantyProductType::RELATED_ITEM_ID] = $relatedItem->getId();
 
         try {
             $cart->addProduct($warranty, $warrantyData);

--- a/Plugin/Checkout/CustomerData/AbstractItemPlugin.php
+++ b/Plugin/Checkout/CustomerData/AbstractItemPlugin.php
@@ -16,6 +16,7 @@ use Extend\Warranty\Model\Product\Type;
 use Extend\Warranty\Helper\Api\Data as DataHelper;
 use Extend\Warranty\Helper\Tracking as TrackingHelper;
 use Magento\Quote\Model\Quote\Item;
+use \Magento\Bundle\Model\Product\Type as BundleProductType;
 
 /**
  * Class AbstractItemPlugin
@@ -75,7 +76,10 @@ class AbstractItemPlugin
         $result['product_image']['isWarranty'] = isset($result['product_type'])
             && $result['product_type'] === Type::TYPE_CODE;
 
-        if ($this->isShoppingCartOffersEnabled() && !$this->hasWarranty($item)) {
+        $isBundle = $item->getProductType() === BundleProductType::TYPE_CODE;
+        $bundleCheck = $isBundle && !$this->dataHelper->isIndividualBundleItemOffersEnabled() || !$isBundle;
+
+        if ($this->isShoppingCartOffersEnabled() && !$this->hasWarranty($item) && $bundleCheck) {
             $result['product_can_add_warranty'] = true;
             $result['warranty_add_url'] = $this->getWarrantyAddUrl();
             $result['product_parent_id'] = $this->getParentId($item);

--- a/Plugin/Checkout/CustomerData/AbstractItemPlugin.php
+++ b/Plugin/Checkout/CustomerData/AbstractItemPlugin.php
@@ -10,6 +10,7 @@
 
 namespace Extend\Warranty\Plugin\Checkout\CustomerData;
 
+use Extend\Warranty\Helper\Data as WarrantyHelper;
 use Magento\Framework\UrlInterface;
 use Magento\Checkout\CustomerData\AbstractItem;
 use Extend\Warranty\Model\Product\Type;
@@ -81,6 +82,7 @@ class AbstractItemPlugin
 
         if ($this->isShoppingCartOffersEnabled() && !$this->hasWarranty($item) && $bundleCheck) {
             $result['product_can_add_warranty'] = true;
+            $result['relatedItemId'] = $item->getId();
             $result['warranty_add_url'] = $this->getWarrantyAddUrl();
             $result['product_parent_id'] = $this->getParentId($item);
             $result['product_is_tracking_enabled'] = $this->isTrackingEnabled();
@@ -92,23 +94,21 @@ class AbstractItemPlugin
     }
 
     /**
-     * Check if has warranty in cart
+     * Check if has warranty in cart by quote Item
      *
      * @param Item $item
      * @return bool
      */
-    private function hasWarranty(Item $item): bool
+    private function hasWarranty(Item $checkQuoteItem): bool
     {
         $hasWarranty = false;
-        $quote = $item->getQuote();
-        $id = $item->getId();
+        $quote = $checkQuoteItem->getQuote();
         $items = $quote->getAllVisibleItems();
         foreach ($items as $item) {
-            if ($item->getProductType() === Type::TYPE_CODE) {
-                $associatedProduct = $item->getOptionByCode(Type::RELATED_ITEM_ID);
-                if ($associatedProduct && $associatedProduct->getValue() === $id) {
-                    $hasWarranty = true;
-                }
+            if ($item->getProductType() === Type::TYPE_CODE
+                && WarrantyHelper::isWarrantyRelatedToQuoteItem($item, $checkQuoteItem)
+            ) {
+                $hasWarranty = true;
             }
         }
 

--- a/Plugin/Checkout/CustomerData/LastOrderedItemsPlugin.php
+++ b/Plugin/Checkout/CustomerData/LastOrderedItemsPlugin.php
@@ -5,7 +5,7 @@
  * @author      Extend Magento Team <magento@guidance.com>
  * @category    Extend
  * @package     Warranty
- * @copyright   Copyright (c) 2021 Extend Inc. (https://www.extend.com/)
+ * @copyright   Copyright (c) 2022 Extend Inc. (https://www.extend.com/)
  */
 
 namespace Extend\Warranty\Plugin\Checkout\CustomerData;
@@ -47,7 +47,7 @@ class LastOrderedItemsPlugin
                 if (
                     $orderItem = $orderItemCollection->getItemById($item['id'])
                 ) {
-                    if ($orderItem && $orderItem->getProductType() == WarrantyProductType::TYPE_CODE) {
+                    if ($orderItem->getProductType() == WarrantyProductType::TYPE_CODE) {
                         unset($result['items'][$key]);
                     }
                 }

--- a/Plugin/Quote/Model/QuotePlugin.php
+++ b/Plugin/Quote/Model/QuotePlugin.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Extend Warranty
+ *
+ * @author      Extend Magento Team <magento@guidance.com>
+ * @category    Extend
+ * @package     Warranty
+ * @copyright   Copyright (c) 2022 Extend Inc. (https://www.extend.com/)
+ */
+
+namespace Extend\Warranty\Plugin\Quote\Model;
+
+use Extend\Warranty\Model\Product\Type;
+use Magento\Quote\Model\Quote\Item;
+
+class QuotePlugin
+{
+    /**
+     * Quote::updateItem could recreate quote_item and it would brake connection between warranty and warrantable item
+     * So we are saving new related item to warranty to save related_item_id
+     * afterwords in \Extend\Warranty\Model\Quote\WarrantyRelation::processRelation
+     *
+     * @param \Magento\Quote\Model\Quote $subject
+     * @param \Magento\Quote\Model\Quote\Item $result
+     * @param integer $itemId
+     * @param $buyRequest
+     * @param $params
+     * @return \Magento\Quote\Model\Quote\Item
+     */
+    public function afterUpdateItem(\Magento\Quote\Model\Quote $subject, $result, $itemId, $buyRequest, $params = null)
+    {
+        if ($result->getId() !== $itemId) {
+            /** @var Item $item */
+            foreach ($subject->getAllItems() as $item) {
+                if ($item->getProductType() != Type::TYPE_CODE) {
+                    continue;
+                }
+                if ($item->getOptionByCode(Type::RELATED_ITEM_ID)
+                    && $itemId == $item->getOptionByCode(Type::RELATED_ITEM_ID)->getValue()
+                ) {
+                    $item->setRelatedItem($result);
+                }
+            }
+        }
+        return $result;
+    }
+}

--- a/ViewModel/Warranty.php
+++ b/ViewModel/Warranty.php
@@ -10,6 +10,7 @@
 
 namespace Extend\Warranty\ViewModel;
 
+use Extend\Warranty\Helper\Data as WarrantyHelper;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\Exception\LocalizedException;
@@ -193,7 +194,7 @@ class Warranty implements ArgumentInterface
     }
 
     /**
-     * Check if has warranty in cart
+     * Check if has warranty in cart by itemId
      *
      * @param CartInterface $quote
      * @param int $id
@@ -202,14 +203,13 @@ class Warranty implements ArgumentInterface
     public function hasWarranty(CartInterface $quote, int $id): bool
     {
         $hasWarranty = false;
-
+        $checkQuoteItem = $quote->getItemById($id);
         $items = $quote->getAllVisibleItems();
         foreach ($items as $item) {
-            if ($item->getProductType() === Type::TYPE_CODE) {
-                $associatedProduct = $item->getOptionByCode(Type::RELATED_ITEM_ID);
-                if ($associatedProduct && (int)$associatedProduct->getValue() === $id) {
-                    $hasWarranty = true;
-                }
+            if(
+                $item->getProductType() === Type::TYPE_CODE
+                && WarrantyHelper::isWarrantyRelatedToQuoteItem($item,$checkQuoteItem)){
+                $hasWarranty = true;
             }
         }
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -302,4 +302,18 @@
                 type="Extend\Warranty\Plugin\Quote\Model\Item\SetItemDataToOrderPlugin"
                 sortOrder="10" />
     </type>
+
+
+    <type name="\Magento\Quote\Model\Quote">
+        <plugin name="extend_warranty_sales_quote"
+                type="\Extend\Warranty\Plugin\Quote\Model\QuotePlugin"/>
+    </type>
+
+    <virtualType name="QuoteRelationsComposite" type="Magento\Framework\Model\ResourceModel\Db\VersionControl\RelationComposite">
+        <arguments>
+            <argument name="relationProcessors" xsi:type="array">
+                <item name="warranty_relation" xsi:type="object">Extend\Warranty\Model\Quote\WarrantyRelation</item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>

--- a/view/adminhtml/templates/items/column/name.phtml
+++ b/view/adminhtml/templates/items/column/name.phtml
@@ -88,16 +88,5 @@ $viewModel = $block->getViewModel();
             <?php endforeach; ?>
         </dl>
     <?php endif; ?>
-
-    <?php if ($viewModel->isLeadEnabled()): ?>
-        <?php $leadToken = $viewModel->getLeadToken($_item); ?>
-
-        <?php if (!empty($leadToken)): ?>
-            <div class="product-lead-token-block">
-                <span><?= $block->escapeHtml(__('Lead Token'))?>: </span>
-                <span><?= $block->escapeHtml($leadToken) ?></span>
-            </div>
-        <?php endif; ?>
-    <?php endif; ?>
     <?= $block->escapeHtml($_item->getDescription()) ?>
 <?php endif; ?>

--- a/view/adminhtml/templates/order/create/items/warranty.phtml
+++ b/view/adminhtml/templates/order/create/items/warranty.phtml
@@ -8,10 +8,12 @@ if ($_item = $block->getItem()):
     $inCartViewModel = $block->getData('viewModel');
     $productType = $_product->getTypeId();
     $isBundle = $productType === \Magento\Bundle\Model\Product\Type::TYPE_CODE;
-    $isBundleAllowed = !$inCartViewModel->isIndividualBundleItemOffersEnabled();
+
+    $bundleCheck = $isBundle && !$inCartViewModel->isIndividualBundleItemOffersEnabled() || !$isBundle;
+
     ?>
 
-    <?php if ($_product->getTypeId() !== 'warranty' && (!$isBundle || $isBundleAllowed)): ?>
+    <?php if ($_product->getTypeId() !== 'warranty' && $bundleCheck): ?>
     <?php if ($inCartViewModel->isExtendEnabled((int)$quote->getStoreId()) && $inCartViewModel->isShoppingCartOffersEnabled()): ?>
         <?php if (!$inCartViewModel->hasWarranty($quote, (int)$_item->getId())): ?>
             <tbody id="warranty-<?= /* @noEscape */

--- a/view/adminhtml/templates/order/view/leads.phtml
+++ b/view/adminhtml/templates/order/view/leads.phtml
@@ -24,6 +24,12 @@ $isExpired = $viewModel->isExpired((string)reset($leadToken));
     && !$viewModel->isWarrantyInLaterOrders($item)
     && !$isExpired): ?>
     <td>
+        <?php if (!empty($leadToken)): ?>
+            <div class="product-lead-token-block">
+                <span><?= $block->escapeHtml(__('Lead Token'))?>: </span>
+                <span><?= $block->escapeHtml(implode(',', $leadToken)) ?></span>
+            </div>
+        <?php endif; ?>
         <div id="extend-offer-<?= /* @noEscape */ str_replace([' ','"'], '', $item->getSku()); ?>"></div>
     </td>
     <script>

--- a/view/frontend/templates/cart/item/renderer/actions/warranty-offers.phtml
+++ b/view/frontend/templates/cart/item/renderer/actions/warranty-offers.phtml
@@ -9,6 +9,7 @@
  */
 /**
  * @var \Magento\Checkout\Block\Cart\Item\Renderer\Actions\Generic $block
+ * @var Magento\Framework\Escaper $escaper
  */
 
 /** @var \Magento\Quote\Model\Quote\Item $_item */
@@ -24,14 +25,15 @@ $productType = $product->getTypeId();
 $isConfigurable = $productType === \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE;
 $isWarrantyItem = $productType === \Extend\Warranty\Model\Product\Type::TYPE_CODE;
 $isBundle = $productType === \Magento\Bundle\Model\Product\Type::TYPE_CODE;
-$isBundleAllowed = !$viewModel->isIndividualBundleItemOffersEnabled();
+
+$bundleCheck = $isBundle && !$viewModel->isIndividualBundleItemOffersEnabled() || !$isBundle;
 ?>
 
 <?php if (
     !$isWarrantyItem &&
     $viewModel->isExtendEnabled() &&
     $viewModel->isShoppingCartOffersEnabled() &&
-    (!$isBundle || $isBundleAllowed)
+    $bundleCheck
 ): ?>
     <?php
     $_itemID = '';
@@ -57,6 +59,7 @@ $isBundleAllowed = !$viewModel->isIndividualBundleItemOffersEnabled();
                 "#warranty-offers-<?= $block->escapeHtmlAttr($_itemID) ?>": {
                     "cartItemWarranty":{
                         "productSku": "<?= $block->escapeJs($_currentSku[$_itemID]) ?>",
+                        "relatedItemId":<?= $escaper->escapeHtmlAttr($_itemID);?>,
                         "addToCartUrl" : "<?= $block->escapeUrl($block->getUrl('warranty/cart/add')) ?>",
                         "buttonEnabled": true,
                         "trackingEnabled": <?= $block->escapeJs($viewModel->isTrackingEnabled() ? 1 : 0) ?>

--- a/view/frontend/templates/cart/item/renderer/actions/warranty-offers.phtml
+++ b/view/frontend/templates/cart/item/renderer/actions/warranty-offers.phtml
@@ -9,7 +9,6 @@
  */
 /**
  * @var \Magento\Checkout\Block\Cart\Item\Renderer\Actions\Generic $block
- * @var Magento\Framework\Escaper $escaper
  */
 
 /** @var \Magento\Quote\Model\Quote\Item $_item */
@@ -59,7 +58,7 @@ $bundleCheck = $isBundle && !$viewModel->isIndividualBundleItemOffersEnabled() |
                 "#warranty-offers-<?= $block->escapeHtmlAttr($_itemID) ?>": {
                     "cartItemWarranty":{
                         "productSku": "<?= $block->escapeJs($_currentSku[$_itemID]) ?>",
-                        "relatedItemId":<?= $escaper->escapeHtmlAttr($_itemID);?>,
+                        "relatedItemId":<?= $block->escapeHtmlAttr($_itemID);?>,
                         "addToCartUrl" : "<?= $block->escapeUrl($block->getUrl('warranty/cart/add')) ?>",
                         "buttonEnabled": true,
                         "trackingEnabled": <?= $block->escapeJs($viewModel->isTrackingEnabled() ? 1 : 0) ?>

--- a/view/frontend/templates/order/item/warranty-offers.phtml
+++ b/view/frontend/templates/order/item/warranty-offers.phtml
@@ -20,7 +20,7 @@ $viewModel = $block->getData('viewModel');
 
 $productType = $product->getTypeId();
 $isBundle = $productType === \Magento\Bundle\Model\Product\Type::TYPE_CODE;
-$isBundleAllowed = !$viewModel->isIndividualBundleItemOffersEnabled();
+$bundleCheck = $isBundle && !$viewModel->isIndividualBundleItemOffersEnabled() || !$isBundle;
 $isWarrantyItem = $productType === \Extend\Warranty\Model\Product\Type::TYPE_CODE;
 
 $leadToken = $viewModel->unserialize($_item->getLeadToken()) ?? [];
@@ -31,7 +31,7 @@ $isExpired = $viewModel->isExpired((string)reset($leadToken));
     && $viewModel->isOrderOffersEnabled()
     && $viewModel->isLeadEnabled()
     && isset($leadToken)
-    && (!$isBundle || $isBundleAllowed)
+    && $bundleCheck
     && !$isExpired): ?>
     <?php $isWarrantyInLaterOrders = $viewModel->isWarrantyInLaterOrders($_item)?>
     <?php if (!$isWarrantyInLaterOrders): ?>

--- a/view/frontend/web/js/cart/cart-item-warranty.js
+++ b/view/frontend/web/js/cart/cart-item-warranty.js
@@ -21,6 +21,7 @@ define([
         options: {
             isInCartPage: true,
             productSku: null,
+            relatedItemId: null,
             addToCartUrl: null,
             addToCartEvent: null,
             buttonEnabled: true,
@@ -43,6 +44,12 @@ define([
         _addToCart: function (warranty) {
             if (!warranty)
                 return;
+
+            if(this.options.relatedItemId){
+                warranty = $.extend({
+                    relatedItemId: this.options.relatedItemId
+                }, warranty);
+            }
 
             $.ajax({
                 url: this.options.addToCartUrl,

--- a/view/frontend/web/js/cart/cart-item-warranty.js
+++ b/view/frontend/web/js/cart/cart-item-warranty.js
@@ -47,7 +47,7 @@ define([
 
             if(this.options.relatedItemId){
                 warranty = $.extend({
-                    relatedItemId: this.options.relatedItemId
+                    related_item_id: this.options.relatedItemId
                 }, warranty);
             }
 

--- a/view/frontend/web/js/product/bundle-warranty.js
+++ b/view/frontend/web/js/product/bundle-warranty.js
@@ -9,10 +9,12 @@
 define([
     'jquery',
     'underscore',
+    'priceUtils',
     'extendWarrantyOffers',
     'simpleProductWarranty',
+    'priceBundle',
     'domReady!'
-], function ($, _) {
+], function ($, _, priceUtils) {
     'use strict';
 
     $.widget('mage.bundleProductWarranty', $.mage.simpleProductWarranty, {
@@ -25,15 +27,15 @@ define([
             insertionPoint: 'div.field.option',
             insertionLogic: 'after',
             formInputName: 'warranty_%s',
-            bundleInputName: 'input[name="bundle_option[%s]"]',
+            bundleInputName: '.bundle-option-%s',
             formInputClass: 'extend-warranty-input',
             selectors: {
                 addToCartForm: '#product_addtocart_form',
                 addToCartButton: '#product-addtocart-button',
-                optionsWrap: 'div.product-options-wrapper'
+                optionsWrap: 'input.bundle.option, select.bundle.option, textarea.bundle.option'
             }
         },
-        warrantyBlocks: [],
+        warrantyBlocks: {},
 
         /**
          * Product warranty offers creation
@@ -42,8 +44,6 @@ define([
         _create: function () {
             this._initElements();
             this._bind();
-
-            this._initProductsWarrantyOffers();
         },
 
         /**
@@ -55,45 +55,30 @@ define([
 
             if (this.options.selectors.optionsWrap) {
                 $(this.options.selectors.optionsWrap, this.mainWrap).on('change', this._updateProductsWarrantyOffers.bind(this));
+                $(this.options.selectors.optionsWrap, this.mainWrap).trigger('change');
             }
-        },
-
-        /**
-         * Initialize warranty offers block for each associated product
-         * @protected
-         */
-        _initProductsWarrantyOffers: function () {
-            _.each(this.options.bundleSkus || [], function (item, index) {
-                var input = $(this.options.bundleInputName.replace('%s', index));
-                if (input.length > 1) {
-                    input = $(this.options.bundleInputName.replace('%s', index) + ':checked');
-                }
-
-                var product = item[input.val()];
-                var warrantyBlock = this._initWarrantyOffersBlock(index, product.sku);
-                this.warrantyBlocks.push(warrantyBlock);
-            }.bind(this));
         },
 
         /**
          * Update the current warranty offers block for each associated product based on their selected configuration
          * @protected
          */
-        _updateProductsWarrantyOffers: function () {
-            var newSkus = [];
+        _updateProductsWarrantyOffers: function (event) {
+            var newSkus = [],
+                bundleOptionElement = $(event.target),
+                optionId = priceUtils.findOptionId(bundleOptionElement),
+                optionValue = $(bundleOptionElement).val()
+            ;
 
-            _.each(this.options.bundleSkus || [], function (item, index) {
-                var input = $(this.options.bundleInputName.replace('%s', index));
-                if (input.length > 1) {
-                    input = $(this.options.bundleInputName.replace('%s', index) + ':checked');
+
+
+            if(this.options.bundleSkus[optionId] && this.options.bundleSkus[optionId][optionValue]){
+                let product = this.options.bundleSkus[optionId][optionValue];
+                if(this.warrantyBlocks[optionId]){
+                    this.warrantyBlocks[optionId].extendWarrantyOffers('updateActiveProduct', product.sku);
+                }else{
+                    this.warrantyBlocks[optionId] = this._initWarrantyOffersBlock(optionId, product.sku);
                 }
-
-                var product = item[input.val()];
-                newSkus.push(product.sku);
-            }.bind(this));
-
-            for (let i = 0; i < this.warrantyBlocks.length; i++) {
-                this.warrantyBlocks[i].extendWarrantyOffers('updateActiveProduct', newSkus[i]);
             }
         },
 

--- a/view/frontend/web/js/view/minicart-mixin.js
+++ b/view/frontend/web/js/view/minicart-mixin.js
@@ -55,12 +55,16 @@ define([
         _initWarrantyOffers: function (cartItem, element) {
             var blockID = 'warranty-offers-' + cartItem.product_id;
             var warrantyElem = $('#' + blockID, element);
+            let relatedItemId = null;
 
             if (!cartItem.product_can_add_warranty) {
                 warrantyElem.remove();
                 return;
             }
 
+            if(cartItem.relatedItemId){
+                relatedItemId = cartItem.relatedItemId;
+            }
             if (!warrantyElem.length) {
                 warrantyElem = $('<div>').attr('id', blockID).addClass(this.warrantyClass);
                 $('div.product-item-details', element).append(warrantyElem);
@@ -69,6 +73,7 @@ define([
             if (!warrantyElem.data('mageCartItemWarranty')) {
                 warrantyElem.cartItemWarranty({
                     isInCartPage: window.location.href === this.shoppingCartUrl,
+                    relatedItemId:relatedItemId,
                     productSku: cartItem.product_sku,
                     addToCartUrl: cartItem.warranty_add_url,
                     buttonEnabled: true,


### PR DESCRIPTION
- updated isIndividualBundleItemOffersEnabled check in cart/item order/item and minicart
- refactored a js for rendering warranty offers for bundle product on PDP
- fixed lead token render for bundler product in admin order view
- fixed issue when warranty added to cart via leadtoken and then being removed by normalizer
- fixed issue with warranty->relatedItemId connection to bundle items when bundle recreated by Quote->updateItem method and bundle losed connection
- made cart be save once instead of be saving on every warranty add when bundle added to cart with multiple warranties
- fixed issue with qty calculation for bundle in normalizer