### PR TITLE
[EX-391] [M2]Cart Normalization does not kick in when a user reorders…

### DIFF
--- a/Plugin/Checkout/Model/CartPlugin.php
+++ b/Plugin/Checkout/Model/CartPlugin.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Extend Warranty
+ *
+ * @author      Extend Magento Team <magento@guidance.com>
+ * @category    Extend
+ * @package     Warranty
+ * @copyright   Copyright (c) 2022 Extend Inc. (https://www.extend.com/)
+ */
+namespace Extend\Warranty\Plugin\Checkout\Model;
+
+use Extend\Warranty\Model\Product\Type as WarrantyProductType;
+
+class CartPlugin
+{
+    /**
+     * @param \Magento\Checkout\Model\Cart $subject
+     * @param \Closure $proceed
+     * @param \Magento\Sales\Model\Order\Item $orderItem
+     * @param true|null $qtyFlag
+     * @return mixed
+     */
+    public function aroundAddOrderItem(
+        \Magento\Checkout\Model\Cart $subject,
+        \Closure $proceed,
+        $orderItem,
+        $qtyFlag = null
+    ) {
+        if ($orderItem->getProductType() == WarrantyProductType::TYPE_CODE
+        ) {
+            return $subject;
+        }
+        return $proceed($orderItem, $qtyFlag);
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -53,4 +53,9 @@
         <plugin name="filterLastOrderItemsFromWarranties"
                 type="Extend\Warranty\Plugin\Checkout\CustomerData\LastOrderedItemsPlugin"/>
     </type>
+
+    <type name="\Magento\Checkout\Model\Cart">
+        <plugin name="check_reorder_items"
+                type="Extend\Warranty\Plugin\Checkout\Model\CartPlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
… a protection plan on an account page

- added Cart plugin to block warranties from being added to cart from ReOrder functionality