### PR TITLE
[EX-408] [M2] Implement checks for object existence in places where null or boolean can be returned instead of an object

### DIFF
--- a/Helper/Tracking.php
+++ b/Helper/Tracking.php
@@ -131,7 +131,11 @@ class Tracking extends \Magento\Framework\App\Helper\AbstractHelper
     public function getQuoteItemForWarrantyItem(Item $quoteItem)
     {
         //find corresponding product and get qty
-        $productSku = (string)$quoteItem->getOptionByCode('associated_product')->getValue();
+        $productSku = $quoteItem->getOptionByCode(Type::ASSOCIATED_PRODUCT)
+            ? (string)$quoteItem->getOptionByCode(Type::ASSOCIATED_PRODUCT)->getValue()
+            : ""
+        ;
+
         /** @var \Magento\Quote\Model\Quote $quote */
         $quote = $quoteItem->getQuote();
         foreach ($quote->getAllItems() as $item) {

--- a/Observer/Checkout/Cart/UpdateItemComplete.php
+++ b/Observer/Checkout/Cart/UpdateItemComplete.php
@@ -80,19 +80,23 @@ class UpdateItemComplete implements \Magento\Framework\Event\ObserverInterface
         $qty = (int)$quoteItem->getQty();
         $origQty = (int)$quoteItem->getOrigData('qty');
         if ($qty <> $origQty) {
-            if ($quoteItem->getProductType() === \Extend\Warranty\Model\Product\Type::TYPE_CODE) {
+            if ($quoteItem->getProductType() === Type::TYPE_CODE) {
                 //send tracking update for the warranty offer
-                $planId = (string)$quoteItem->getOptionByCode('warranty_id')->getValue();
-                /** @var \Magento\Quote\Model\Quote\Item $item */
-                $item = $this->_trackingHelper->getQuoteItemForWarrantyItem($quoteItem);
-                $trackingData = [
-                    'eventName'        => 'trackOfferUpdated',
-                    'productId'        => $quoteItem->getSku(),
-                    'planId'           => $planId,
-                    'warrantyQuantity' => $qty,
-                    'productQuantity'  => (int)$item->getQty(),
-                ];
-                $this->_trackingHelper->setTrackingData($trackingData);
+                $planId = $quoteItem->getOptionByCode(Type::WARRANTY_ID);
+
+                if($planId && $planId->getValue()){
+                    /** @var \Magento\Quote\Model\Quote\Item $item */
+                    $item = $this->_trackingHelper->getQuoteItemForWarrantyItem($quoteItem);
+                    $trackingData = [
+                        'eventName'        => 'trackOfferUpdated',
+                        'productId'        => $quoteItem->getSku(),
+                        'planId'           => $planId,
+                        'warrantyQuantity' => $qty,
+                        'productQuantity'  => (int)$item->getQty(),
+                    ];
+                    $this->_trackingHelper->setTrackingData($trackingData);
+                }
+
             } elseif (!count($this->_trackingHelper->getWarrantyItemsForQuoteItem($quoteItem))) {
                 //there is no associated warranty item, just send tracking for the product update
                 $trackingData = [

--- a/Observer/Checkout/Cart/UpdateItemsAfter.php
+++ b/Observer/Checkout/Cart/UpdateItemsAfter.php
@@ -9,6 +9,8 @@
  */
 namespace Extend\Warranty\Observer\Checkout\Cart;
 
+use Extend\Warranty\Model\Product\Type;
+
 /**
  * Class UpdateItemsAfter
  *
@@ -72,22 +74,24 @@ class UpdateItemsAfter implements \Magento\Framework\Event\ObserverInterface
             if ($qty == $origQty) {
                 continue;
             }
-            if ($quoteItem->getProductType() === \Extend\Warranty\Model\Product\Type::TYPE_CODE) {
+            if ($quoteItem->getProductType() === Type::TYPE_CODE) {
                 if ($this->dataHelper->isBalancedCart()) {
                     continue;
                 }
                 //send tracking update for the warranty offer
-                $planId = (string)$quoteItem->getOptionByCode('warranty_id')->getValue();
+                $planId = $quoteItem->getOptionByCode(Type::WARRANTY_ID);
                 /** @var \Magento\Quote\Model\Quote\Item $item */
                 $item = $this->_trackingHelper->getQuoteItemForWarrantyItem($quoteItem);
-                $trackingData = [
-                    'eventName'        => 'trackOfferUpdated',
-                    'productId'        => $item->getSku(),
-                    'planId'           => $planId,
-                    'warrantyQuantity' => $qty,
-                    'productQuantity'  => (int)$item->getQty(),
-                ];
-                $this->_trackingHelper->setTrackingData($trackingData);
+                if($planId && $planId->getValue()){
+                    $trackingData = [
+                        'eventName'        => 'trackOfferUpdated',
+                        'productId'        => $item->getSku(),
+                        'planId'           => $planId->getValue(),
+                        'warrantyQuantity' => $qty,
+                        'productQuantity'  => (int)$item->getQty(),
+                    ];
+                    $this->_trackingHelper->setTrackingData($trackingData);
+                }
             } else {
                 $warrantyItems = $this->_trackingHelper->getWarrantyItemsForQuoteItem($quoteItem);
                 if (!count($warrantyItems)) {

--- a/Observer/QuoteRemoveItem.php
+++ b/Observer/QuoteRemoveItem.php
@@ -53,32 +53,40 @@ class QuoteRemoveItem implements \Magento\Framework\Event\ObserverInterface
         //if the item being removed is a warranty offer, send tracking for the offer removed, if tracking enabled
         if ($quoteItem->getProductType() === WarrantyProductType::TYPE_CODE) {
             if ($this->_trackingHelper->isTrackingEnabled()) {
-                $warrantySku = (string)$quoteItem->getOptionByCode('associated_product')->getValue();
-                $planId = (string)$quoteItem->getOptionByCode('warranty_id')->getValue();
-                $trackingData = [
-                    'eventName' => 'trackOfferRemovedFromCart',
-                    'productId' => $warrantySku,
-                    'planId'    => $planId,
-                ];
+                $warrantySku = $quoteItem->getOptionByCode(WarrantyProductType::ASSOCIATED_PRODUCT)
+                    ? (string)$quoteItem->getOptionByCode(WarrantyProductType::ASSOCIATED_PRODUCT)->getValue()
+                    : '';
 
-                $this->_trackingHelper->setTrackingData($trackingData);
+                $planId = $quoteItem->getOptionByCode(WarrantyProductType::WARRANTY_ID)
+                    ? (string)$quoteItem->getOptionByCode(WarrantyProductType::WARRANTY_ID)->getValue()
+                    : '';
 
-                $trackProduct = true;
-                $items = $quote->getAllItems();
-                foreach ($items as $item) {
-                    if ($item->getSku() === $warrantySku) {
-                        $trackProduct = false;
-                        break;
-                    }
-                }
-
-                if ($trackProduct) {
+                if($warrantySku && $planId) {
                     $trackingData = [
-                        'eventName' => 'trackProductRemovedFromCart',
+                        'eventName' => 'trackOfferRemovedFromCart',
                         'productId' => $warrantySku,
+                        'planId' => $planId,
                     ];
 
                     $this->_trackingHelper->setTrackingData($trackingData);
+
+                    $trackProduct = true;
+                    $items = $quote->getAllItems();
+                    foreach ($items as $item) {
+                        if ($item->getSku() === $warrantySku) {
+                            $trackProduct = false;
+                            break;
+                        }
+                    }
+
+                    if ($trackProduct) {
+                        $trackingData = [
+                            'eventName' => 'trackProductRemovedFromCart',
+                            'productId' => $warrantySku,
+                        ];
+
+                        $this->_trackingHelper->setTrackingData($trackingData);
+                    }
                 }
             }
             return;


### PR DESCRIPTION
[EX-408] [M2] Implement checks for object existence in places where null or boolean can be returned instead of an object
- added check for custom options to avoid Fatal Error

[EX-408]: https://helloextend.atlassian.net/browse/EX-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ