### PR TITLE
[EX-440] [M2] Configurable product add to cart fails when sku already…

### DIFF
--- a/Model/Normalizer.php
+++ b/Model/Normalizer.php
@@ -190,7 +190,7 @@ class Normalizer
             }
         } elseif (count($warranties) === 1) {
             $warranty = array_shift($warranties);
-            if ($productItemQty !== $warranty->getQty()) {
+            if ($productItemQty !== (int) $warranty->getQty()) {
                 $warranty->setQty($productItemQty);
                 $this->quoteItemRepository->save($warranty);
             }

--- a/Model/Product/Type.php
+++ b/Model/Product/Type.php
@@ -14,6 +14,7 @@ use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product\Type\AbstractType;
 use Magento\Catalog\Model\Product;
 use Extend\Warranty\Helper\Data;
+use Magento\Framework\Exception\LocalizedException;
 use \Magento\Framework\Exception\NoSuchEntityException;
 
 /**
@@ -136,9 +137,15 @@ class Type extends AbstractType
      * @param Product $product
      * @param string $processMode
      * @return array|Product|Product[]|string
+     * @throws LocalizedException
      */
     protected function _prepareProduct(\Magento\Framework\DataObject $buyRequest, $product, $processMode)
     {
+        if(!$buyRequest->getProduct()){
+            $this->_logger->error(sprintf(__('BuyRequest is not valid, product option is not provided.')));
+            throw new LocalizedException(__('Warranty was unable to be added. Please try again.'));
+        }
+
         $price = $this->helper->removeFormatPrice($buyRequest->getPrice());
 
         $buyRequest->setData('custom_price', $price);


### PR DESCRIPTION
… exists with another option selected

- fixed issue with useless save of quoteRepository, what produced issue with failing adding warranty item
- added exception for cases when buy request is not valid