### PR TITLE
[EX-126] [M2] Send historical orders to Orders API

### DIFF
--- a/Model/Api/Sync/Orders/HistoricalOrdersRequest.php
+++ b/Model/Api/Sync/Orders/HistoricalOrdersRequest.php
@@ -67,6 +67,7 @@ class HistoricalOrdersRequest extends AbstractRequest
     public function create(array $orders, int $currentBatch = 1): bool
     {
         $url = $this->apiUrl . self::CREATE_ORDER_ENDPOINT;
+        $url .= "?historical=true";
         $historicalOrders = [];
 
         foreach ($orders as $order) {

--- a/Model/RelationProcessor/DefaultProcessor.php
+++ b/Model/RelationProcessor/DefaultProcessor.php
@@ -109,7 +109,7 @@ class DefaultProcessor implements RelationProcessorInterface
      */
     public function getOfferOrderItemSku($orderItem): string
     {
-        return $orderItem->getProduct()->getSku();
+        return $orderItem->getProduct() ? $orderItem->getProduct()->getSku() : $orderItem->getSku();
     }
 
     /**


### PR DESCRIPTION
- added historical param to endpoint url
- added check for orders item product before getting the sku as product could be deleted at moment when order sync running