### PR TITLE
EX-425  [M2] Orders POST is not providing the correct Product Purchase Price, while other fields are missing from the line item or order header

### DIFF
--- a/Model/Api/Request/OrderBuilder.php
+++ b/Model/Api/Request/OrderBuilder.php
@@ -216,6 +216,7 @@ class OrderBuilder
             'customer' => $customerData,
             'lineItems' => $lineItems,
             'total' => $transactionTotal,
+            'taxCostTotal' => $this->helper->formatPrice($order->getBaseTaxAmount()),
             'productCostTotal' => $this->helper->formatPrice($order->getBaseSubtotal()),
             'discountAmountTotal' => $this->helper->formatPrice(abs($order->getBaseDiscountAmount())),
             'storeId' => $extendStoreId,

--- a/Model/Api/Request/OrderBuilder.php
+++ b/Model/Api/Request/OrderBuilder.php
@@ -137,11 +137,20 @@ class OrderBuilder
             $currencyCode = $store->getBaseCurrencyCode() ?? Currency::DEFAULT_CURRENCY;
         }
 
-        $transactionTotal = $this->helper->formatPrice($order->getBaseGrandTotal());
         $lineItem = [];
 
-        $discountAmount = $this->helper->formatPrice($orderItem->getBaseDiscountAmount());
-        $taxCost = $this->helper->formatPrice($orderItem->getBaseTaxAmount());
+        $transactionTotal = $this->helper->formatPrice($order->getGrandTotal());
+        $discountAmount = $this->helper->formatPrice($orderItem->getDiscountAmount() / $qty);
+        $taxCost = $this->helper->formatPrice($orderItem->getTaxAmount() / $qty);
+        $purchasePrice = $this->helper->formatPrice($orderItem->getRowTotal() / $qty);
+
+        if ($orderItem->getProductType() == Type::TYPE_CODE && $associatedOrderItem = $this->getAssociatedOrderItem($orderItem)) {
+            $relatedOrderItemQty = $associatedOrderItem->getQtyOrdered();
+            $discountAmount = $this->helper->formatPrice($associatedOrderItem->getDiscountAmount() / $relatedOrderItemQty);
+            $taxCost = $this->helper->formatPrice($associatedOrderItem->getTaxAmount() / $relatedOrderItemQty);
+            $purchasePrice = $this->helper->formatPrice($associatedOrderItem->getRowTotal() / $relatedOrderItemQty);
+        }
+
 
         if ($type == \Extend\Warranty\Model\Orders::CONTRACT) {
             $productSku = $orderItem->getProductOptionByCode(Type::ASSOCIATED_PRODUCT);
@@ -150,6 +159,7 @@ class OrderBuilder
             $plan = $this->getPlan($orderItem);
 
             $product = $this->prepareProductPayload($productSku);
+            $product['purchasePrice'] = $purchasePrice;
 
             $lineItem = [
                 'status' => $this->getStatus(),
@@ -163,6 +173,7 @@ class OrderBuilder
         } elseif ($type == \Extend\Warranty\Model\Orders::LEAD) {
             $productSku = $this->warrantyRelation->getOfferOrderItemSku($orderItem);
             $product = $this->prepareProductPayload($productSku);
+            $product['purchasePrice'] = $purchasePrice;
 
             $lineItem = [
                 'status' => $this->getStatus(),
@@ -216,9 +227,9 @@ class OrderBuilder
             'customer' => $customerData,
             'lineItems' => $lineItems,
             'total' => $transactionTotal,
-            'taxCostTotal' => $this->helper->formatPrice($order->getBaseTaxAmount()),
-            'productCostTotal' => $this->helper->formatPrice($order->getBaseSubtotal()),
-            'discountAmountTotal' => $this->helper->formatPrice(abs($order->getBaseDiscountAmount())),
+            'taxCostTotal' => $this->helper->formatPrice($order->getTaxAmount()),
+            'productCostTotal' => $this->helper->formatPrice($order->getSubtotal()),
+            'discountAmountTotal' => $this->helper->formatPrice(abs($order->getDiscountAmount())),
             'storeId' => $extendStoreId,
             'storeName' => $extendStoreName,
             'transactionId' => $order->getIncrementId(),
@@ -240,8 +251,7 @@ class OrderBuilder
         $extendStoreId = $this->apiHelper->getStoreId(ScopeInterface::SCOPE_STORES, $store->getId());
         $extendStoreName = $this->apiHelper->getStoreName(ScopeInterface::SCOPE_STORES, $store->getId());
 
-        $transactionTotal = $this->helper->formatPrice($order->getBaseGrandTotal());
-        $lineItem = [];
+        $transactionTotal = $this->helper->formatPrice($order->getGrandTotal());
         $lineItems = [];
 
         foreach ($order->getItems() as $orderItem) {
@@ -254,6 +264,8 @@ class OrderBuilder
             } else {
                 $product = $this->prepareProductPayload($productSku);
             }
+
+            $product['purchasePrice'] = $this->helper->formatPrice($orderItem->getRowTotal() / $qty);
 
             if (empty($product)) {
                 continue;
@@ -462,6 +474,23 @@ class OrderBuilder
         }
 
         return $customer;
+    }
+
+    /**
+     * @param OrderItemInterface $warrantyOrderItem
+     * @return OrderItemInterface|null
+     */
+    protected function getAssociatedOrderItem($warrantyOrderItem)
+    {
+        $order = $warrantyOrderItem->getOrder();
+
+        foreach ($order->getAllItems() as $item) {
+            if ($this->warrantyRelation->isWarrantyRelatedToOrderItem($warrantyOrderItem, $item)) {
+                return $item;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/Model/Api/Request/ProductDataBuilder.php
+++ b/Model/Api/Request/ProductDataBuilder.php
@@ -170,7 +170,7 @@ class ProductDataBuilder
         }
 
         $payload = [
-            'category'          => $categories ? : 'No category',
+            'category'          => $categories ? : 'No Category',
             'description'       => $description,
             'price'             => $price,
             'title'             => (string)$product->getName(),

--- a/Model/Api/Request/ProductDataBuilder.php
+++ b/Model/Api/Request/ProductDataBuilder.php
@@ -170,7 +170,7 @@ class ProductDataBuilder
         }
 
         $payload = [
-            'category'          => $categories,
+            'category'          => $categories ? : 'No category',
             'description'       => $description,
             'price'             => $price,
             'title'             => (string)$product->getName(),

--- a/Model/Api/Request/ProductDataBuilder.php
+++ b/Model/Api/Request/ProductDataBuilder.php
@@ -150,7 +150,7 @@ class ProductDataBuilder
         $currencyCode = $this->getCurrencyCode($storeId);
 
         $price = [
-            'amount'        => $this->helper->formatPrice($this->_calculateSyncProductPrice($product, $scopeType, $scopeId)),
+            'amount'        => $this->helper->formatPrice($this->calculateSyncProductPrice($product, $scopeType, $scopeId)),
             'currencyCode'  => $currencyCode,
         ];
 
@@ -194,7 +194,16 @@ class ProductDataBuilder
         return $payload;
     }
 
-    private function _calculateSyncProductPrice(ProductInterface $product, $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeId = null) {
+    /**
+     * Calculates price with checking if special price should be used
+     * for syncing
+     *
+     * @param ProductInterface $product
+     * @param $scopeType
+     * @param $scopeId
+     * @return float|null
+     */
+    public function calculateSyncProductPrice(ProductInterface $product, $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeId = null) {
         $price = $product->getPrice();
         $specialPricesEnabled = $this->_getIsSpecialPricesSyncEnabled($scopeType, $scopeId);
         $specialPrice = $this->catalogProductType->priceFactory($product->getTypeId())->getFinalPrice(1, $product);

--- a/Model/Api/Sync/Orders/OrdersRequest.php
+++ b/Model/Api/Sync/Orders/OrdersRequest.php
@@ -40,7 +40,7 @@ class OrdersRequest extends AbstractRequest
                 $url,
                 Zend_Http_Client::POST,
                 [
-                    'Accept'                  => 'application/json; version=2021-07-01',
+                    'Accept'                  => 'application/json; version=2022-02-01',
                     'Content-Type'            => 'application/json',
                     self::ACCESS_TOKEN_HEADER => $this->apiKey,
                     'X-Idempotency-Key'       => $this->getUuid4()


### PR DESCRIPTION
- added missed fields on order and line item level
- changed logic for product listPrice to follow special price configuration
- added fix for cases when product has not category assigned
- added taxCostTotal for order level when order created
- updated version for API Order Request