### PR TITLE
[EX-479] [M2] Orders POST is not providing the correct Product Purcha…

### DIFF
--- a/Observer/CreateLead.php
+++ b/Observer/CreateLead.php
@@ -130,7 +130,7 @@ class CreateLead implements ObserverInterface
                 $orderItem->setOrder($order);
                 if ($orderItem->getProductType() === Type::TYPE_CODE) {
                     $warrantyItems[] = $orderItem;
-                } else {
+                } elseif(!$orderItem->getParentItem()) {
                     $productItems[] = $orderItem;
                 }
             }


### PR DESCRIPTION
…se Price, while other fields are missing from the line item or order header

- fixed issue with doubling lead orders for configurables