### PR TITLE
feat: [MINT-1744] use sales_order_invoice_save_after event for invoice observer

### DIFF
--- a/Observer/ContractCreate/InvoiceObserver.php
+++ b/Observer/ContractCreate/InvoiceObserver.php
@@ -71,6 +71,16 @@ class InvoiceObserver implements ObserverInterface
     {
         $event = $observer->getEvent();
         $invoice = $event->getInvoice();
+
+        /**
+         * Ideally we would respond to 'sales_order_invoice_pay', but there are some merchants which have plugins
+         * that create an invoice payment prior to the order existing in the database. This requires us to listen to
+         * 'sales_order_invoice_save_after' and check if the invoice was paid before we continue.
+         */
+        if (!$invoice->wasPayCalled()) {
+            return;
+        }
+
         $order = $invoice->getOrder();
 
         $storeId = $order->getStoreId();

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -22,7 +22,7 @@
     <event name="sales_model_service_quote_submit_success">
         <observer name="extend_warranty_create_order_observer" instance="Extend\Warranty\Observer\CreateOrder"/>
     </event>
-    <event name="sales_order_invoice_pay">
+    <event name="sales_order_invoice_save_after">
         <observer name="extend_warranty_create_warranty_invoice_after_observer"
                   instance="Extend\Warranty\Observer\ContractCreate\InvoiceObserver"/>
     </event>


### PR DESCRIPTION
- Change invoice observer to trigger off of `sales_order_invoice_save_after` so that an order exists (we need the order id to create contracts)
- This also follows the same convention used in the new Extend Module