### PR TITLE
Patch Release : Update Warranty.php

### DIFF
--- a/ViewModel/Warranty.php
+++ b/ViewModel/Warranty.php
@@ -645,7 +645,7 @@ class Warranty implements ArgumentInterface
         /** @var Collection $categoryCollection */
         $categoryCollection = $product->getCategoryCollection();
         $categoryCollection->addAttributeToSelect('name');
-        $categoryCollection->addIsActiveFilter();
+        $categoryCollection->addFieldToFilter('is_active', 1);
         $categoryCollection->addAttributeToSort('created_at', 'desc');
         $category = $categoryCollection->getFirstItem();
 


### PR DESCRIPTION
changed addIsActiveFilter to addFieldToFilter because when using permissions on categories, the addIsActiveFilter generates errors