### PR TITLE
Patch Release : Allow tracking of Parent Order when purchasing from a Lead Token

### DIFF
--- a/Helper/Api/Magento/Data.php
+++ b/Helper/Api/Magento/Data.php
@@ -15,6 +15,7 @@ use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Serialize\Serializer\Json;
 use Magento\Sales\Api\Data\OrderItemExtensionFactory;
+use Magento\Sales\Api\Data\OrderItemExtensionInterface;
 use Magento\Sales\Api\Data\OrderItemInterface;
 use Magento\Sales\Model\Order\Item;
 
@@ -36,6 +37,7 @@ class Data extends AbstractHelper
     public const WARRANTY_TERM      = 'warranty_term';
     public const LEAD_TOKEN         = 'lead_token';
     public const PLAN_TYPE          = 'plan_type';
+    public const PARENT_ORDER_ID    = 'parent_order_id';
 
     /**
      * Order Extension Attributes Factory

--- a/Model/Orders.php
+++ b/Model/Orders.php
@@ -290,7 +290,7 @@ class Orders
             $extendOrder = false;
         }
 
-        
+
         if ($extendOrder){
             $this->getOrderRequest($order->getStoreId())
             ->cancel($extendOrder->getExtendOrderId());

--- a/Plugin/Catalog/Helper/Product/Configuration/GetCustomOptionsPlugin.php
+++ b/Plugin/Catalog/Helper/Product/Configuration/GetCustomOptionsPlugin.php
@@ -13,6 +13,7 @@ namespace Extend\Warranty\Plugin\Catalog\Helper\Product\Configuration;
 use Magento\Catalog\Helper\Product\Configuration;
 use Magento\Catalog\Model\Product\Configuration\Item\ItemInterface;
 use Extend\Warranty\Model\Product\Type;
+use Magento\Sales\Api\OrderRepositoryInterface;
 
 /**
  * Class GetCustomOptionsPlugin
@@ -29,6 +30,23 @@ class GetCustomOptionsPlugin
      * @param ItemInterface $item
      * @return array
      */
+
+    /**
+     * @var OrderRepositoryInterface
+     */
+    protected $orderRepository;
+
+    /**
+     * Constructor
+     *
+     * @param OrderRepositoryInterface $orderRepository
+     */
+    public function __construct(OrderRepositoryInterface $orderRepository)
+    {
+        $this->orderRepository = $orderRepository;
+    }
+
+
     public function afterGetCustomOptions(Configuration $subject, array $result, ItemInterface $item): array
     {
         $product = $item->getProduct();
@@ -61,6 +79,19 @@ class GetCustomOptionsPlugin
                 $customOptions[] = [
                     'label' => __($termLabel),
                     'value' => $optionValue,
+                ];
+            }
+
+            //Custom option parent order ID (this is displayed in the cart, so use Increment ID)
+            $parentOrderIdOption = $product->getCustomOption(Type::ASSOCIATED_PARENT_ORDER_ID);
+            if ($parentOrderIdOption && $parentOrderIdOption->getValue()) {
+                $parentOrderId      = (int) $parentOrderIdOption->getValue();
+                $order              = $this->orderRepository->get($parentOrderId);
+                $incrementId        = $order->getIncrementId();
+                $parentOrderLabel   = Type::PARENT_ORDER_LABEL;
+                $customOptions[]    = [
+                    'label' => __($parentOrderLabel),
+                    'value' => $incrementId,
                 ];
             }
 

--- a/ViewModel/Warranty.php
+++ b/ViewModel/Warranty.php
@@ -38,6 +38,7 @@ use Magento\Sales\Api\OrderItemRepositoryInterface;
 use Magento\Sales\Model\Order\Item;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
 
 /**
  * Class Warranty
@@ -129,6 +130,11 @@ class Warranty implements ArgumentInterface
     protected $helper;
 
     /**
+     * @var OrderRepositoryInterface
+     */
+    protected $orderRepository;
+
+    /**
      * Warranty constructor
      *
      * @param DataHelper $dataHelper
@@ -144,6 +150,7 @@ class Warranty implements ArgumentInterface
      * @param AdminSession $adminSession
      * @param LeadInfo $leadInfo
      * @param WarrantyRelation $warrantyRelation
+     * @param OrderRepositoryInterface $orderRepository
      */
     public function __construct(
         DataHelper                   $dataHelper,
@@ -159,7 +166,8 @@ class Warranty implements ArgumentInterface
         AdminSession                 $adminSession,
         LeadInfo                     $leadInfo,
         WarrantyRelation             $warrantyRelation,
-        ExtendHelper                 $helper
+        ExtendHelper                 $helper,
+        OrderRepositoryInterface     $orderRepository
     )
     {
         $this->dataHelper = $dataHelper;
@@ -176,6 +184,7 @@ class Warranty implements ArgumentInterface
         $this->adminSession = $adminSession;
         $this->leadInfo = $leadInfo;
         $this->warrantyRelation = $warrantyRelation;
+        $this->orderRepository = $orderRepository;
     }
 
     /**
@@ -399,7 +408,7 @@ class Warranty implements ArgumentInterface
         $relationSku = $this->warrantyRelation->getOfferOrderItemSku($orderItem);
         return !empty($this->warrantyRelation->getWarrantyByRelationSku($relationSku));
     }
-    
+
     /**
      * Check does quote have warranty item for the item
      * Kept for backwards compatibility with Hyva module
@@ -655,5 +664,15 @@ class Warranty implements ArgumentInterface
                 ? $category->getName()
                 : \Extend\Warranty\Model\Api\Request\ProductDataBuilder::NO_CATEGORY_DEFAULT_VALUE
         ];
+    }
+
+    public function getOrderIncrementId($orderId = null){
+        if ($orderId){
+            $order = $this->orderRepository->get($orderId);
+            $incrementId = $order->getIncrementId();
+            if ($incrementId){
+                return $incrementId;
+            }
+        }
     }
 }

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -4,6 +4,7 @@
     <table name="sales_order_item">
         <column xsi:type="mediumtext" name="contract_id" nullable="true" comment="Extend Contract Id"/>
         <column xsi:type="mediumtext" name="lead_token" nullable="true" comment="Extend Lead Token"/>
+        <column xsi:type="int" name="extend_parent_order_id"  nullable="true" unsigned="true" comment="Extend Parent Order ID"/>
     </table>
     <table name="extend_warranty_contract_create">
         <column xsi:type="int" name="id" identity="true" nullable="false" unsigned="true" comment="ID"/>

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -3,7 +3,7 @@
 /**
  * Extend Warranty
  *
- * @author      Extend Magento Team <magento@guidance.com>
+ * @author      Extend Magento Team <magento@extend.com>
  * @category    Extend
  * @package     Warranty
  * @copyright   Copyright (c) 2021 Extend Inc. (https://www.extend.com/)
@@ -21,6 +21,7 @@
         <attribute code="refund" type="boolean" />
         <attribute code="lead_token" type="string" />
         <attribute code="plan_type" type="string" />
+        <attribute code="parent_order_id" type="string" />
     </extension_attributes>
     <extension_attributes for="Magento\Quote\Api\Data\CartItemInterface">
         <attribute code="lead_token" type="string" />

--- a/view/adminhtml/templates/items/column/name.phtml
+++ b/view/adminhtml/templates/items/column/name.phtml
@@ -37,7 +37,11 @@ use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
         $_refunded = (isset($_productOptions["refund"]) && true == $_productOptions["refund"])
             ? "-- All refunded --" : '';
-        ;
+
+        //retrieve Parent Order ID if present
+        $currentOrderId     = $_item->getOrderId();
+        $parentOrderId      = isset($_productOptions["parent_order_id"]) ? $_productOptions["parent_order_id"] : null;
+        $incrementId        = $parentOrderId ? $viewModel->getOrderIncrementId($parentOrderId) : null;
         ?>
         <div class="product-warranty-block">
             <br />
@@ -48,6 +52,11 @@ use Magento\Framework\View\Helper\SecureHtmlRenderer;
                 <?= $block->escapeHtml($_refunded); ?>
             <?php endif; ?>
             <br /><span><?= /* @noEscape */ $block->escapeHtml(__('Plan ID'))?>: </span><?= /* @noEscape */ $_planId ?>
+
+            <!-- show Parent Order ID for Post Purchase Warranty -->
+            <?php if ($parentOrderId && ($parentOrderId <> $currentOrderId) && $incrementId) :?>
+                <br /><br/><span><?= /* @noEscape */ $block->escapeHtml(__('Parent Order ID'))?>: </span><?= /* @noEscape */ $incrementId ?>
+            <?php endif; ?>
         </div>
     <?php endif; ?>
 


### PR DESCRIPTION
where to see the changes
- consume a lead token and add the warranty to the cart.
- in the minicart/cart you will see the details of the warranty now include "Parent Order" and the increment ID of the parent order
- in the database, you now have an extra column in sales_order_item called "extend_parent_order_id" that will have the order ID (not the increment ID) of the parent order from where the lead Token originates