### PR TITLE
PUE orders update the parent order item with warranty orders

### DIFF
--- a/view/adminhtml/templates/items/column/name.phtml
+++ b/view/adminhtml/templates/items/column/name.phtml
@@ -58,6 +58,23 @@ use Magento\Framework\View\Helper\SecureHtmlRenderer;
                 <br /><br/><span><?= /* @noEscape */ $block->escapeHtml(__('Parent Order ID'))?>: </span><?= /* @noEscape */ $incrementId ?>
             <?php endif; ?>
         </div>
+        <!-- if not a warranty but PUE order information is present -->
+        <?php else: ?>
+        <?php
+            $_productOptions = $_item->getProductOptions();
+            $warrantyOrderId      = $_productOptions["info_buyRequest"]["extend_warranty_order_id"] ?? null;
+            if ($warrantyOrderId && is_array($warrantyOrderId)){
+                ?>
+                <div class="product-warranty-block">
+                    <br /><span> <?php echo "Warranty Order ID :";
+                    foreach ($warrantyOrderId as $warrantyOrder ) {
+                        echo "<br><a href='" . $block->getUrl('sales/order/view', ['order_id' => $warrantyOrder]) . "'>" . $viewModel->getOrderIncrementId($warrantyOrder) . "</a>";
+                    }
+                    ?>
+                </div>
+        <?php }  ?>
+
+
     <?php endif; ?>
 
     <?php if ($block->getOrderOptions()): ?>

--- a/view/frontend/templates/order/item/additional-info.phtml
+++ b/view/frontend/templates/order/item/additional-info.phtml
@@ -18,10 +18,9 @@
 
     $_item = $block->getItem();
     $block->getChildBlock('order.item.warranty')->setItem($_item);
+    $_productOptions = $_item->getProductOptions();
 
     if ($_item->getProductType()=='warranty'){
-
-        $_productOptions = $_item->getProductOptions();
         $_planId = isset($_productOptions["warranty_id"]) ? $_productOptions["warranty_id"] : '';
         $_parentSku= isset($_productOptions["associated_product"]) ? $_productOptions["associated_product"] : '';
         $_contractID = $viewModel->unserialize($_item->getContractId()) ?? [];
@@ -51,6 +50,19 @@
             if ($parentOrderId && ($parentOrderId <> $currentOrderId) && $incrementId) {
                 echo " Parent Order: <a href='". $block->getUrl('sales/order/view', ['order_id' => $parentOrderId])."'>".$incrementId."</a>";
             }
+    }else{
+
+        // product is not a warranty item. check if there is a warranty purchased tied to it
+        $currentOrderId         = $_item->getOrderId();
+        $warrantyOrderId        = $_productOptions["info_buyRequest"]["extend_warranty_order_id"] ?? null;
+       // $warrantyIncrementId    = $warrantyOrderId ? $viewModel->getOrderIncrementId($warrantyOrderId) : null;
+
+        if ($warrantyOrderId && is_array($warrantyOrderId) && ($warrantyOrderId <> $currentOrderId)) {
+            echo "Warranty Order ID :";
+                    foreach ($warrantyOrderId as $warrantyOrder ) {
+                        echo "<br><a href='" . $block->getUrl('sales/order/view', ['order_id' => $warrantyOrder]) . "'>" . $viewModel->getOrderIncrementId($warrantyOrder) . "</a>";
+                    }
+        }
     }
 ?>
 <?=  $block->getChildHtml('', false);


### PR DESCRIPTION
this update allows for a given post purchase order coming in with only a warranty item to update the parent order (without warranty), to link the new order with the warranty.

for example
- order A has a warrantable item but no warranty
- order B has a warranty only, for the item in order A.

the previous patch brought the order A information in the order B, so the user can refer to the original order
this patch updates order A to have a link to order B, so the user can refer to the warranty order if they view the original order