### PR TITLE
Fix fatal error on line 427, as method hasWarranty expects product id instead of sku

### DIFF
--- a/ViewModel/Warranty.php
+++ b/ViewModel/Warranty.php
@@ -413,10 +413,10 @@ class Warranty implements ArgumentInterface
      * Check does quote have warranty item for the item
      * Kept for backwards compatibility with Hyva module
      *
-     * @param int $productId
+     * @param int $quoteItemId
      * @return bool
      */
-    public function isWarrantyInQuote(int $productId): bool
+    public function isWarrantyInQuote(int $quoteItemId): bool
     {
         try {
             $quote = $this->checkoutSession->getQuote();
@@ -424,7 +424,7 @@ class Warranty implements ArgumentInterface
             $quote = null;
         }
         if ($quote) {
-            $hasWarranty = $this->hasWarranty($quote, $productId);
+            $hasWarranty = $this->hasWarranty($quote, $quoteItemId);
         }
         return $hasWarranty ?? false;
     }


### PR DESCRIPTION
There is a fatal error in the module
main.CRITICAL: TypeError: Extend\Warranty\ViewModel\Warranty::hasWarranty(): Argument #2 ($id) must be of type int, string given, called in .../vendor/extend/module-warranty/ViewModel/Warranty.php on line 427 and defined in .../vendor/extend/module-warranty/ViewModel/Warranty.php:227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal warranty verification method to use product identifiers for improved data handling. User-facing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->