### PR TITLE
Update Installation.php

### DIFF
--- a/ViewModel/Installation.php
+++ b/ViewModel/Installation.php
@@ -155,6 +155,10 @@ class Installation implements ArgumentInterface
             } catch (InvalidArgumentException $exception) {
                 $jsonConfig = '';
             }
+
+            if (isset($config['region'])){
+                unset($config['region']);
+            }
         }
 
         return $jsonConfig;
@@ -261,11 +265,17 @@ class Installation implements ArgumentInterface
      */
     private function getRegion($storeId = null): string
     {
+        return null;
+        /* 
+         * Removed Nov. 2025 if the payload has a region (form the store) , it overrides the customer's region.
+         * This bypasses the location filtering. let the API determine the region based on the customer.
+
         return (string)$this->scopeConfig->getValue(
             \Magento\Config\Model\Config\Backend\Admin\Custom::XML_PATH_GENERAL_COUNTRY_DEFAULT,
             ScopeInterface::SCOPE_STORES,
             $storeId
         );
+        */
     }
 
     /**

--- a/ViewModel/Installation.php
+++ b/ViewModel/Installation.php
@@ -155,10 +155,6 @@ class Installation implements ArgumentInterface
             } catch (InvalidArgumentException $exception) {
                 $jsonConfig = '';
             }
-
-            if (isset($config['region'])){
-                unset($config['region']);
-            }
         }
 
         return $jsonConfig;
@@ -263,7 +259,7 @@ class Installation implements ArgumentInterface
      *
      * @return string
      */
-    private function getRegion($storeId = null): string
+    private function getRegion($storeId = null): ?string
     {
         return null;
         /* 


### PR DESCRIPTION
change the region value in the payload. as it's always grabbing the region from the store, and bypasses the geofencing on the API side. Having the API determine the region is the better way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where region configuration was incorrectly persisted in the installation JSON configuration, preventing unwanted region-based behavior from being carried into the final setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->